### PR TITLE
Fix NDK build

### DIFF
--- a/dist-build/android-arm.sh
+++ b/dist-build/android-arm.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export CFLAGS="-Os -mthumb -marm -march=armv6"
-TARGET_ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"
+TARCH=arm TARGET_ARCH=arm HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-armv7.sh
+++ b/dist-build/android-armv7.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export CFLAGS="-Os -mfloat-abi=softfp -mfpu=vfpv3-d16 -mthumb -marm -march=armv7-a"
-TARGET_ARCH=armv7 HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"
+TARCH=arm TARGET_ARCH=armv7 HOST_COMPILER=arm-linux-androideabi "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-build.sh
+++ b/dist-build/android-build.sh
@@ -28,7 +28,7 @@ export PATH="${PATH}:${TOOLCHAIN_DIR}/bin"
 rm -rf "${TOOLCHAIN_DIR}" "${PREFIX}"
 
 $MAKE_TOOLCHAIN --platform="${NDK_PLATFORM:-android-14}" \
-                --arch="$TARGET_ARCH" \
+                --arch="$TARCH" \
                 --install-dir="$TOOLCHAIN_DIR" && \
 ./configure --host="${HOST_COMPILER}" \
             --with-sysroot="${TOOLCHAIN_DIR}/sysroot" \

--- a/dist-build/android-mips.sh
+++ b/dist-build/android-mips.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export CFLAGS="-Os"
-TARGET_ARCH=mips HOST_COMPILER=mipsel-linux-android "$(dirname "$0")/android-build.sh"
+TARCH=mips TARGET_ARCH=mips HOST_COMPILER=mipsel-linux-android "$(dirname "$0")/android-build.sh"

--- a/dist-build/android-x86.sh
+++ b/dist-build/android-x86.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export CFLAGS="-Os"
-TARGET_ARCH=x86 HOST_COMPILER=i686-linux-android "$(dirname "$0")/android-build.sh"
+TARCH=x86 TARGET_ARCH=x86 HOST_COMPILER=i686-linux-android "$(dirname "$0")/android-build.sh"


### PR DESCRIPTION
fix clowwindy/ShadowVPNAndroid#6
make-standalone-toolchain.sh does not accept `armv7` as an option for `--arch`
NDK build fails with error: "Invalid --arch armv7"