### PR TITLE
only the first one of default gateway(s) should be used.:)

### DIFF
--- a/samples/client_up.sh
+++ b/samples/client_up.sh
@@ -15,7 +15,7 @@ ifconfig $intf mtu $mtu
 
 # get current gateway
 echo get the original default gateway
-gateway=$(ip route show 0/0 | grep via | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')
+gateway=$(ip route show 0/0 | grep via | head -n1 | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')
 
 # turn on NAT over VPN
 iptables -t nat -A POSTROUTING -o $intf -j MASQUERADE

--- a/samples/server_up.sh
+++ b/samples/server_up.sh
@@ -14,7 +14,7 @@ ifconfig $intf 10.7.0.1 netmask 255.255.255.0
 ifconfig $intf mtu $mtu
 
 # get default gateway
-gw_intf=`ip route show | grep '^default' | sed -e 's/.* dev \([^ ]*\).*/\1/'`
+gw_intf=`ip route show | grep '^default' | head -n1 | sed -e 's/.* dev \([^ ]*\).*/\1/'`
 
 # turn on NAT over gw_intf and VPN
 if !(iptables-save -t nat | grep -q "$gw_intf (shadowvpn)"); then


### PR DESCRIPTION
i encountered problems when there are multiple gateways(eg: lan and wlan were connected to te different networks).
shadowvpn doesn't work properly on choosing the right gateway.
% ip r 
default via xx.x.xxx.x dev lan0  metric 244 
default via xxx.xxx.xxx.xx dev wlan0  metric 345 

should look like following after connect.
% ip r | grep '^default'            
default dev tun0  scope link 
default via  xxx.xxx.xxx.xx dev wlan0  metric 345 