### PR TITLE
Improved config and script files

### DIFF
--- a/samples/client.conf
+++ b/samples/client.conf
@@ -1,45 +1,46 @@
 # ShadowVPN config example
 
-# notice: do not put space before or after "="
+# Notice: do not put space before or after "="
 
-# server listen address
+# Server listen address
 server=127.0.0.1
 
-# server listen port
+# Server listen port
 port=1123
 
-# password to use
-# you can generate one by:
-# dd if=/dev/urandom bs=64 count=1 | md5sum
+# Password to use to encrypt traffic. You can generate one by running:
+#     dd if=/dev/urandom bs=64 count=1 | md5sum
 password=my_password
 
-# server or client
+# Server or client mode
 mode=client
 
-# max source ports
-# must be the SAME with server or won't work properly
+# Max source ports. Must be the SAME with server or VPN won't work properly.
 concurrency=1
 
-# the MTU of VPN device
-# 1492(Ethernet) - 20(IPv4, or 40 for IPv6) - 8(UDP) - 24(ShadowVPN)
+# MTU of VPN tunnel device. Use the following formula to calculate:
+#     1492 (Ethernet) - 20 (IPv4, or 40 for IPv6) - 8 (UDP) - 24 (ShadowVPN)
 mtu=1440
 
-# uncomment to specify tunnel device name
-# tunX for linux or bsd, utunX for darwin
+# Tunnel device name. tunX for Linux or BSD, utunX for Darwin.
 intf=tun0
 
-# the script to run after VPN is created
-# use this script to set up routes, NAT, etc
-# configuration in this file will be set as environment variables
+# Local IP and subnet of the VPN tunnel. Prefer /31 subnets for point-to-point
+# links. For more information please read RFC 3021.
+net=10.7.0.1/31
+
+# Script to run after VPN is created. All key-value pairs (except password) in
+# this file will be passed to the script as environment variables. Use this
+# script to set up routes, turn on NAT, etc.
 up=/etc/shadowvpn/client_up.sh
 
-# the script to run before stopping VPN
-# use this script to restore routes, NAT, etc
-# configuration in this file will be set as environment variables
+# Script to run before stopping VPN. All key-value pairs (except password) in
+# this file will be passed to the script as environment variables. Use this
+# script to restore routes, turn off NAT, etc.
 down=/etc/shadowvpn/client_down.sh
 
 # PID file path
 pidfile=/var/run/shadowvpn.pid
 
-# log file path
+# Log file path
 logfile=/var/log/shadowvpn.log

--- a/samples/client_down.sh
+++ b/samples/client_down.sh
@@ -1,24 +1,20 @@
 #!/bin/sh
 
-# example client down script
-# will be executed when client is down
+# This script will be executed when client is down. All key value pairs (except
+# password) in ShadowVPN config file will be passed to this script as
+# environment variables.
 
-# all key value pairs in ShadowVPN config file will be passed to this script
-# as environment variables, except password
-
-# uncomment if you want to turn off IP forwarding
-# sysctl -w net.ipv4.ip_forward=0
+# Turn off IP forwarding
+#sysctl -w net.ipv4.ip_forward=0
 
 # turn off NAT over VPN
 iptables -t nat -D POSTROUTING -o $intf -j MASQUERADE
 iptables -D FORWARD -i $intf -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -D FORWARD -o $intf -j ACCEPT
 
-# change routing table
-echo rollback the default route
+# Restore routing table
 ip route del $server
-ip route del 0.0.0.0/1
-ip route del 128.0.0.0/1
-echo default route changed to original route
+ip route del   0/1
+ip route del 128/1
 
 echo $0 done

--- a/samples/client_up.sh
+++ b/samples/client_up.sh
@@ -1,32 +1,26 @@
 #!/bin/sh
 
-# example client up script
-# will be executed when client is up
+# This script will be executed when client is up. All key value pairs (except
+# password) in ShadowVPN config file will be passed to this script as
+# environment variables.
 
-# all key value pairs in ShadowVPN config file will be passed to this script
-# as environment variables, except password
-
-# turn on IP forwarding
+# Turn on IP forwarding
 sysctl -w net.ipv4.ip_forward=1
 
-# configure IP address and MTU of VPN interface
-ifconfig $intf 10.7.0.2 netmask 255.255.255.0
-ifconfig $intf mtu $mtu
+# Configure IP address and MTU of VPN interface
+ip addr add $net dev $intf
+ip link set $intf mtu $mtu
 
-# get current gateway
-echo get the original default gateway
-gateway=$(ip route show 0/0 | grep via | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}')
-
-# turn on NAT over VPN
+# Turn on NAT over VPN
 iptables -t nat -A POSTROUTING -o $intf -j MASQUERADE
 iptables -I FORWARD 1 -i $intf -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -I FORWARD 1 -o $intf -j ACCEPT
 
-# change routing table
-echo override the default route
-ip route add $server via $gateway
-ip route add 0.0.0.0/1 via 10.7.0.1
-ip route add 128.0.0.0/1 via 10.7.0.1
-echo default route changed to 10.7.0.1
+# Direct route to VPN server's public IP via current gateway
+ip route add $server via $(ip route show 0/0 | awk '{print $3}')
+
+# Shadow default route using two /1 subnets
+ip route add   0/1 dev $intf
+ip route add 128/1 dev $intf
 
 echo $0 done

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -1,44 +1,46 @@
 # ShadowVPN config example
 
-# notice: do not put space before or after "="
+# Notice: do not put space before or after "="
 
-# server listen address
+# Server listen address
 server=0.0.0.0
 
-# server listen port
+# Server listen port
 port=1123
 
-# password to use
-# you can generate one by:
-# dd if=/dev/urandom bs=64 count=1 | md5sum
+# Password to encrypt traffic. You can generate one by running:
+#     dd if=/dev/urandom bs=64 count=1 | md5sum
 password=my_password
 
-# server or client
+# Server or client mode
 mode=server
 
-# max source ports
-# must be the SAME with client or won't work properly
+# Max source ports. Must be the SAME with client or it won't work properly.
 concurrency=1
 
-# the MTU of VPN device
-# 1492(Ethernet) - 20(IPv4, or 40 for IPv6) - 8(UDP) - 24(ShadowVPN)
+# MTU of VPN tunnel device. Use the following formula to calculate:
+#     1492 (Ethernet) - 20 (IPv4, or 40 for IPv6) - 8 (UDP) - 24 (ShadowVPN)
 mtu=1440
 
-# tunnel device name
+# Tunnel device name. tunX for Linux or BSD, utunX for Darwin.
 intf=tun0
 
-# the script to run after VPN is created
-# use this script to set up routes, NAT, etc
-# configuration in this file will be set as environment variables
+# Local IP and subnet of the VPN tunnel. Prefer /31 subnets for point-to-point
+# links. For more information please read RFC 3021.
+net=10.7.0.0/31
+
+# Script to run after VPN is created. All key-value pairs (except password) in
+# this file will be passed to the script as environment variables. Use this
+# script to set up routes, turn on NAT, etc.
 up=/etc/shadowvpn/server_up.sh
 
-# the script to run before stopping VPN
-# use this script to restore routes, NAT, etc
-# configuration in this file will be set as environment variables
-down=/etc/shadowvpn/server_down.sh
+# Script to run before stopping VPN. All key-value pairs (except password) in
+# this file will be passed to the script as environment variables. Use this
+# script to restore routes, turn off NAT, etc.
+down=/etc/shadowvpn/client_down.sh
 
 # PID file path
 pidfile=/var/run/shadowvpn.pid
 
-# log file path
+# Log file path
 logfile=/var/log/shadowvpn.log

--- a/samples/server_down.sh
+++ b/samples/server_down.sh
@@ -1,24 +1,21 @@
 #!/bin/sh
 
-# example server down script
-# will be executed when server is down
+# This script will be executed when server is down. All key value pairs (except
+# password) in ShadowVPN config file will be passed to this script as
+# environment variables.
 
-# all key value pairs in ShadowVPN config file will be passed to this script
-# as environment variables, except password
+# Turn off IP forwarding
+#sysctl -w net.ipv4.ip_forward=0
 
-# uncomment if you want to turn off IP forwarding
-# sysctl -w net.ipv4.ip_forward=0
+# Get default gateway interface
+gw_intf=$(ip route show 0/0 | awk '{print $5}')
 
-# get default gateway
-gw_intf=`ip route show | grep '^default' | sed -e 's/.* dev \([^ ]*\).*/\1/'`
-
-# turn off NAT over gw_intf and VPN
+# Turn off NAT over default gateway interface and VPN
 iptables -t nat -D POSTROUTING -o $gw_intf -m comment --comment "$gw_intf (shadowvpn)" -j MASQUERADE
 iptables -D FORWARD -i $gw_intf -o $intf -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -D FORWARD -i $intf -o $gw_intf -j ACCEPT
 
-# turn off MSS fix
-# MSS = MTU - TCP header - IP header
+# Turn off MSS fix (MSS = MTU - TCP header - IP header)
 iptables -t mangle -D FORWARD -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 echo $0 done

--- a/samples/server_up.sh
+++ b/samples/server_up.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# This script will be executed when server is up. All key value pairs (except
+# password) in ShadowVPN config file will be passed to this script as
+# environment variables.
 
 # Turn on IP forwarding
 sysctl -w net.ipv4.ip_forward=1

--- a/samples/server_up.sh
+++ b/samples/server_up.sh
@@ -1,20 +1,15 @@
 #!/bin/sh
 
-# example server up script
-# will be executed when server is up
 
-# all key value pairs in ShadowVPN config file will be passed to this script
-# as environment variables, except password
-
-# turn on IP forwarding
+# Turn on IP forwarding
 sysctl -w net.ipv4.ip_forward=1
 
-# configure IP address and MTU of VPN interface
-ifconfig $intf 10.7.0.1 netmask 255.255.255.0
-ifconfig $intf mtu $mtu
+# Configure IP address and MTU of VPN interface
+ip addr add $net dev $intf
+ip link set $intf mtu $mtu
 
-# get default gateway
-gw_intf=`ip route show | grep '^default' | sed -e 's/.* dev \([^ ]*\).*/\1/'`
+# Get default gateway interface
+gw_intf=$(ip route show 0/0 | awk '{print $5}')
 
 # turn on NAT over gw_intf and VPN
 if !(iptables-save -t nat | grep -q "$gw_intf (shadowvpn)"); then
@@ -23,8 +18,7 @@ fi
 iptables -A FORWARD -i $gw_intf -o $intf -m state --state RELATED,ESTABLISHED -j ACCEPT
 iptables -A FORWARD -i $intf -o $gw_intf -j ACCEPT
 
-# turn on MSS fix
-# MSS = MTU - TCP header - IP header
+# Turn on MSS fix (MSS = MTU - TCP header - IP header)
 iptables -t mangle -A FORWARD -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
 
 echo $0 done


### PR DESCRIPTION
- Use iproute2 instead of net-tools (ifconfig) to set MTU and tunnel
  subnet since net-tools has long been deprecated.
- Use /31 subnets for point-to-point VPN links instead of /24 per RFC
  3021.
- Move MTU and subnet config from scripts to config files so that
  multiple instances of server/client can share the same pair of up/down
  scripts.
- Slightly improved comments.