### PR TITLE
Fix and improve config and script files for both Linux and Windows

### DIFF
--- a/samples/client_up.sh
+++ b/samples/client_up.sh
@@ -10,6 +10,7 @@ sysctl -w net.ipv4.ip_forward=1
 # Configure IP address and MTU of VPN interface
 ip addr add $net dev $intf
 ip link set $intf mtu $mtu
+ip link set $intf up
 
 # Turn on NAT over VPN
 iptables -t nat -A POSTROUTING -o $intf -j MASQUERADE

--- a/samples/server_down.sh
+++ b/samples/server_down.sh
@@ -8,7 +8,7 @@
 #sysctl -w net.ipv4.ip_forward=0
 
 # Get default gateway interface
-gw_intf=$(ip route show 0/0 | awk '{print $3}')
+gw_intf=$(ip route show 0/0 | awk '{print $5}')
 
 # Turn off NAT over default gateway interface and VPN
 iptables -t nat -D POSTROUTING -o $gw_intf -m comment --comment "$gw_intf (shadowvpn)" -j MASQUERADE

--- a/samples/server_down.sh
+++ b/samples/server_down.sh
@@ -8,7 +8,7 @@
 #sysctl -w net.ipv4.ip_forward=0
 
 # Get default gateway interface
-gw_intf=$(ip route show 0/0 | awk '{print $5}')
+gw_intf=$(ip route show 0/0 | awk '{print $3}')
 
 # Turn off NAT over default gateway interface and VPN
 iptables -t nat -D POSTROUTING -o $gw_intf -m comment --comment "$gw_intf (shadowvpn)" -j MASQUERADE

--- a/samples/server_up.sh
+++ b/samples/server_up.sh
@@ -13,7 +13,7 @@ ip link set $intf mtu $mtu
 ip link set $intf up
 
 # Get default gateway interface
-gw_intf=$(ip route show 0/0 | awk '{print $3}')
+gw_intf=$(ip route show 0/0 | awk '{print $5}')
 
 # turn on NAT over gw_intf and VPN
 if !(iptables-save -t nat | grep -q "$gw_intf (shadowvpn)"); then

--- a/samples/server_up.sh
+++ b/samples/server_up.sh
@@ -10,9 +10,10 @@ sysctl -w net.ipv4.ip_forward=1
 # Configure IP address and MTU of VPN interface
 ip addr add $net dev $intf
 ip link set $intf mtu $mtu
+ip link set $intf up
 
 # Get default gateway interface
-gw_intf=$(ip route show 0/0 | awk '{print $5}')
+gw_intf=$(ip route show 0/0 | awk '{print $3}')
 
 # turn on NAT over gw_intf and VPN
 if !(iptables-save -t nat | grep -q "$gw_intf (shadowvpn)"); then

--- a/samples/windows/client.conf
+++ b/samples/windows/client.conf
@@ -15,14 +15,17 @@ password=my_password
 mode=client
 
 # local tunnel ip address (required)
-tunip=10.7.0.2
+tunip=10.7.0.1
+
+# Max source ports. Must be the SAME with server or VPN won't work properly.
+concurrency=1
 
 # the MTU of VPN device
 # 1492(Ethernet) - 20(IPv4, or 40 for IPv6) - 8(UDP) - 24(ShadowVPN)
 mtu=1440
 
 # tun/tap interface name
-intf=Local Area Connection 2
+intf=Ethernet 2
 
 # the script to run after VPN is created
 # use this script to set up routes, NAT, etc

--- a/samples/windows/client_down.bat
+++ b/samples/windows/client_down.bat
@@ -6,8 +6,8 @@ REM all key value pairs in ShadowVPN config file will be passed to this script
 REM as environment variables, except password
 
 REM user-defined variables
-SET remote_tun_ip=10.7.0.1
-SET orig_intf="Local Area Connection"
+SET remote_tun_ip=10.7.0.0
+SET orig_intf="Ethernet"
 
 REM revert ip settings
 netsh interface ip set interface %orig_intf% ignoredefaultroutes=disabled > NUL
@@ -21,5 +21,6 @@ route delete %server% > NUL
 
 REM revert dns server
 netsh interface ip set dns name="%intf%" source=dhcp > NUL
+netsh interface ip set dns name="%orig_intf%" source=dhcp > NUL
 
 ECHO %0 done

--- a/samples/windows/client_up.bat
+++ b/samples/windows/client_up.bat
@@ -6,9 +6,9 @@ REM all key value pairs in ShadowVPN config file will be passed to this script
 REM as environment variables, except password
 
 REM user-defined variables
-SET remote_tun_ip=10.7.0.1
+SET remote_tun_ip=10.7.0.0
 SET dns_server=8.8.8.8
-SET orig_intf="Local Area Connection"
+SET orig_intf="Ethernet"
 
 REM exclude remote server in routing table
 for /F "tokens=3" %%* in ('route print ^| findstr "\<0.0.0.0\>"') do set "orig_gw=%%*"
@@ -34,5 +34,6 @@ ECHO default route changed to %remote_tun_ip%
 
 REM change dns server
 netsh interface ip set dns name="%intf%" static %dns_server% > NUL
+netsh interface ip set dns name="%orig_intf%" static %dns_server% > NUL
 
 ECHO %0 done


### PR DESCRIPTION
Linux:
Fix `tun0` is not up while ShadowVPN starts (both server and client).

Windows:
Update `tunip` and `remote_tun_ip` to match the recent server config file changes `net=10.7.0.0/31`.
Add `concurrency` in `client.conf`.

Fix a problem that Windows 10 wont use VPN's DNS server (this even happens with Microsoft's PPTP,
I dont know if it's intentional), Windows 10 will always use the Ethernet's DNS server, so we can set DNS for `orig_intf` in `client_up.bat` and restore it to DHCP in `client_down.bat`, same as `intf`.

Update `intf` and `orig_intf`, use the default interface name of Windows 8.1 and Windows 10 English version.
